### PR TITLE
shutdown fix and promisify callback-based functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ try {
 
 // standard promises
 this.server.start()
-    .then(() => { console.log('do work...') })
-    .then(() => { this.server.stop() })
+    .then(() => console.log('do work...'))
+    .then(() => this.server.stop())
     .catch((error) => console.log(error));
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,25 @@ Installation:
 Migrating from 1.x to 2.x:
 1. Change grpc dependecy from this `import * as grpc from "grpc";` by this: `import * as grpc from "@grpc/grpc-js";`
 
-2. A callback function is a must to be provided, upon GrpcMockServer instance cunstruction:
+2. Handle `start` and `stop` functions which are now asynchronous and return Promises:
 ```typescript
-this.server = new GrpcMockServer((error: Error | null, port: Number) => {
-    if(error) {
-        throw new Error("Failed initializing Mock GRPC server on port: " + port);
-    } else {
-        console.log("Mock GRPC server is listening on port: " + port);
-        this.initMockServer();
-    }
-}, "127.0.0.1:50777");
-```          
+this.server = new GrpcMockServer();
+
+// async / await
+try {
+    await this.server.start();
+    console.log('do work...');
+    await this.server.stop();
+} catch (error) {
+    console.log(error);
+}
+
+// standard promises
+this.server.start()
+    .then(() => { console.log('do work...') })
+    .then(() => { this.server.stop() })
+    .catch((error) => console.log(error));
+```
 
 Usage example:
 ```typescript
@@ -31,7 +39,7 @@ private static readonly PKG_NAME: string = "com.alenon.example";
 private static readonly SERVICE_NAME: string = "ExampleService";
 
 ...
-    
+
 const implementations = {
     ex1: (call: any, callback: any) => {
         const response: any =

--- a/src/GrpcMockServer.ts
+++ b/src/GrpcMockServer.ts
@@ -43,32 +43,29 @@ export class GrpcMockServer {
 
   public async start(): Promise<GrpcMockServer> {
     log.debug('Starting gRPC mock server ...');
-    await this.bind();
-    this.server.start();
-    return this;
-  }
 
-  public async stop(): Promise<GrpcMockServer> {
-    log.debug('Stopping gRPC mock server ...');
-    await this.shutdown();
-    return this;
-  }
-
-  private async bind(): Promise<number> {
-    return new Promise((resolve, reject) => {
+    await new Promise<number>((resolve, reject) => {
       this.server.bindAsync(
         this.serverAddress,
         grpc.ServerCredentials.createInsecure(),
         (error, port) => error ? reject(error) : resolve(port)
       );
     });
+
+    this.server.start();
+
+    return this;
   }
 
-  private async shutdown(): Promise<void> {
-    return new Promise((resolve, reject) => {
+  public async stop(): Promise<GrpcMockServer> {
+    log.debug('Stopping gRPC mock server ...');
+
+    await new Promise<void>((resolve, reject) => {
       this.server.tryShutdown(
         (error) => error ? reject(error) : resolve()
       );
     });
+
+    return this;
   }
 }

--- a/src/GrpcMockServer.ts
+++ b/src/GrpcMockServer.ts
@@ -7,15 +7,9 @@ export class GrpcMockServer {
   private readonly _server: grpc.Server;
 
   public constructor(
-    callback: (error: Error | null, port: number) => void,
-    public serverAddress: string = '127.0.0.1:50777'
+    public readonly serverAddress: string = '127.0.0.1:50777'
   ) {
     this._server = new grpc.Server();
-    this.server.bindAsync(
-      this.serverAddress,
-      grpc.ServerCredentials.createInsecure(),
-      callback
-    );
   }
 
   public addService(
@@ -47,15 +41,34 @@ export class GrpcMockServer {
     return this._server;
   }
 
-  public start(): GrpcMockServer {
+  public async start(): Promise<GrpcMockServer> {
     log.debug('Starting gRPC mock server ...');
+    await this.bind();
     this.server.start();
     return this;
   }
 
-  public stop(): GrpcMockServer {
+  public async stop(): Promise<GrpcMockServer> {
     log.debug('Stopping gRPC mock server ...');
-    this.server.forceShutdown();
+    await this.shutdown();
     return this;
+  }
+
+  private async bind(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      this.server.bindAsync(
+        this.serverAddress,
+        grpc.ServerCredentials.createInsecure(),
+        (error, port) => error ? reject(error) : resolve(port)
+      );
+    });
+  }
+
+  private async shutdown(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.server.tryShutdown(
+        (error) => error ? reject(error) : resolve()
+      );
+    });
   }
 }

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -3,70 +3,56 @@ import * as grpc from '@grpc/grpc-js';
 import { GrpcMockServer } from '../src/GrpcMockServer';
 import { ProtoUtils } from '../src/utils/ProtoUtils';
 
-import { assert } from 'console';
-
 const PKG_NAME = 'com.alenon.example';
 const SERVICE_NAME = 'ExampleService';
 const PROTO_PATH: string = __dirname + '/resources/example.proto';
 
-test('integration test for the server/client communication', (done) => {
-  runServer((error: Error | null, response: any): void => {
-    try {
-      expect(response).toBe('the result we expect to get');
-      done();
-    } catch (error) {
-      done(error);
-    }
-  });
-}, 10000);
-
-function runServer(
-  testResultCallback: (error: Error | null, message: string) => void
-): void {
+test('integration test for the server/client communication', async () => {
   const pkgDef: grpc.GrpcObject = grpc.loadPackageDefinition(
     proto_loader.loadSync(PROTO_PATH)
   );
+
   const proto: any = ProtoUtils.getProtoFromPkgDefinition(
     'com.alenon.example',
     pkgDef
   );
 
-  const server: GrpcMockServer = new GrpcMockServer(
-    (error: Error | null, port: number) => {
-      if (error) {
-        testResultCallback(
-          new Error('Failed initializing Mock GRPC server on port: ' + port),
-          ''
-        );
-        server.stop();
-      } else {
-        console.log('Mock GRPC server is listening on port: ' + port);
+  const server: GrpcMockServer = new GrpcMockServer();
 
-        const implementations = {
-          ex1: (call: any, callback: any) => {
-            const response: any = new proto.ExampleResponse.constructor({
-              msg: 'the result we expect to get'
-            });
-            callback(null, response);
-          }
-        };
-
-        server.addService(PROTO_PATH, PKG_NAME, SERVICE_NAME, implementations);
-        server.start();
-
-        const client: any = new proto.ExampleService(
-          '127.0.0.1:50777',
-          grpc.credentials.createInsecure()
-        );
-        const request: any = new proto.ExampleRequest.constructor({
-          msg: 'the message'
-        });
-
-        client.ex1(request, (error: any, response: any) => {
-          testResultCallback(null, response.msg);
-          server.stop();
-        });
-      }
+  const implementations = {
+    ex1: (call: any, callback: any) => {
+      const response: any = new proto.ExampleResponse.constructor({
+        msg: 'the result we expect to get'
+      });
+      callback(null, response);
     }
+  };
+
+  server.addService(PROTO_PATH, PKG_NAME, SERVICE_NAME, implementations);
+
+  try {
+    await server.start();
+    console.log(`Mock GRPC server is listening at: ${server.serverAddress}`);
+  } catch (error) {
+    throw new Error(`Failed initializing Mock GRPC server at: ${server.serverAddress}`)
+  }
+
+  const client: any = new proto.ExampleService(
+    '127.0.0.1:50777',
+    grpc.credentials.createInsecure()
   );
-}
+
+  const request: any = new proto.ExampleRequest.constructor({
+    msg: 'the message'
+  });
+
+  const response = await new Promise<any>((resolve, reject) => {
+    client.ex1(request, (error: any, response: any) => {
+      error ? reject(error) : resolve(response);
+    });
+  })
+
+  expect(response.msg).toBe('the result we expect to get');
+
+  await server.stop();
+}, 10000);


### PR DESCRIPTION
Hey @alenon I've made some improvements to `GrpcMockServer`:
- Moved `bindAsync` from constructor to `start` function
- Replaced `forceShutdown` with `tryShutdown`
- Promisified `bindAsync` and `tryShutdown`

The only real change is using `tryShutdown` instead of `forceShutdown`. I was getting sporadic `14 UNAVAILABLE: Connection dropped` errors with `forceShutdown` and I suspect it's because `forceShutdown` is async but it doesn't expose a callback param which causes a race condition when you want to start the server immediately after stopping it.

Let me know what you think!