### PR TITLE
feat: support multiple proto files (#992)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules
 
 # Intellij
 .idea
+tsconfig.tsbuildinfo

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,80 @@
+# Examples
+
+This directory contains examples demonstrating how to use grpc-mock-server.
+
+## Basic Example - Single Proto File
+
+**File**: `example.ts`
+
+Demonstrates the basic usage with a single proto file:
+
+```typescript
+import { GrpcMockServer } from '../src/GrpcMockServer';
+
+const server = new GrpcMockServer();
+
+server.addService(
+  __dirname + '/example.proto',
+  'com.alenon.example',
+  'ExampleService',
+  implementations
+);
+```
+
+**Run**: `npm run example`
+
+## Multi-Proto Example - Multiple Proto Files
+
+**Files**: `multi-proto-example.ts`, `user.proto`, `address.proto`
+
+Demonstrates how to use multiple proto files with cross-package imports:
+
+```typescript
+server.addService(
+  [
+    __dirname + '/user.proto',
+    __dirname + '/address.proto'
+  ],
+  'user',
+  'UserService',
+  implementations,
+  {
+    includeDirs: [__dirname],
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true
+  }
+);
+```
+
+The `user.proto` imports `Address` message from `address.proto`:
+
+```protobuf
+// user.proto
+import "address.proto";
+
+message User {
+  string name = 1;
+  common.Address address = 2;  // From address.proto
+}
+```
+
+**Run**: `npm run multi-proto-example`
+
+## Key Points
+
+1. **Single Proto**: Simple usage with one proto file
+2. **Multiple Proto**: Use array of proto files with proper options:
+   - `includeDirs`: Directories to search for imported files
+   - `keepCase`: Preserve field name casing (snake_case)
+   - `defaults`, `oneofs`: Handle protobuf features properly
+3. **Cross-Package Imports**: Proto files can import messages from other packages 
+
+Mock server listening at: 127.0.0.1:50777
+GetUser called with ID: 123
+User response: {
+  name: 'John Doe',
+  address: { postal_code: '12345', city: 'San Francisco', country: 'USA' }
+} 

--- a/example/address.proto
+++ b/example/address.proto
@@ -4,4 +4,6 @@ package common;
 
 message Address {
   string postal_code = 1;
-}
+  string city = 2;
+  string country = 3;
+} 

--- a/example/example.ts
+++ b/example/example.ts
@@ -1,75 +1,56 @@
-import * as proto_loader from '@grpc/proto-loader';
-import * as grpc from '@grpc/grpc-js';
 import { GrpcMockServer } from '../src/GrpcMockServer';
-import { ProtoUtils } from '../src/utils/ProtoUtils';
 
-class Example {
-  private static readonly PROTO_PATH: string = __dirname + '/example.proto';
-  private static readonly PKG_NAME: string = 'com.alenon.example';
-  private static readonly SERVICE_NAME: string = 'ExampleService';
-  private readonly server: GrpcMockServer;
-  private readonly pkgDef: any;
-  private readonly proto: any;
+async function basicExample() {
+  // Create mock server
+  const server = new GrpcMockServer();
 
-  constructor() {
-    this.pkgDef = grpc.loadPackageDefinition(
-      proto_loader.loadSync(Example.PROTO_PATH)
-    );
-    this.proto = ProtoUtils.getProtoFromPkgDefinition(
-      'com.alenon.example',
-      this.pkgDef
-    );
-
-    this.server = new GrpcMockServer();
-  }
-
-  public async run(): Promise<void> {
-    await this.initMockServer();
-
-    const client: any = new this.proto.ExampleService(
-      '127.0.0.1:50777',
-      grpc.credentials.createInsecure()
-    );
-    const request: any = new this.proto.ExampleRequest.constructor({
-      msg: 'the message'
-    });
-
-    const response = await new Promise<any>((resolve, reject) => {
-      client.ex1(request, (error: any, response: any) => {
-        error ? reject(error) : resolve(response);
-      });
-    });
-
-    console.log(response.msg);
-
-    await this.server.stop();
-  }
-
-  private async initMockServer() {
-    const implementations = {
-      ex1: (call: any, callback: any) => {
-        const response: any = new this.proto.ExampleResponse.constructor({
-          msg: 'the response message'
-        });
-        callback(null, response);
-      }
-    };
-
-    this.server.addService(
-      Example.PROTO_PATH,
-      Example.PKG_NAME,
-      Example.SERVICE_NAME,
-      implementations
-    );
-
-    try {
-      await this.server.start();
-      console.log(`Mock GRPC server is listening at: ${this.server.serverAddress}`);
-    } catch (error) {
-      throw new Error(`Failed initializing Mock GRPC server at: ${this.server.serverAddress}`);
+  // Define service implementation
+  const implementations = {
+    ex1: (call: any, callback: any) => {
+      console.log('Received request:', call.request.msg);
+      callback(null, { msg: 'Hello from mock server!' });
     }
-  }
+  };
+
+  // Add service to server
+  server.addService(
+    __dirname + '/example.proto',
+    'com.alenon.example',
+    'ExampleService',
+    implementations
+  );
+
+  // Start server
+  await server.start();
+  console.log(`Mock server listening at: ${server.serverAddress}`);
+
+  // Create client and make request
+  const grpc = require('@grpc/grpc-js');
+  const proto_loader = require('@grpc/proto-loader');
+  const { ProtoUtils } = require('../src/utils/ProtoUtils');
+
+  const pkgDef = grpc.loadPackageDefinition(
+    proto_loader.loadSync(__dirname + '/example.proto')
+  );
+  const proto = ProtoUtils.getProtoFromPkgDefinition('com.alenon.example', pkgDef);
+
+  const client = new proto.ExampleService(
+    '127.0.0.1:50777',
+    grpc.credentials.createInsecure()
+  );
+
+  // Make request
+  const response = await new Promise<any>((resolve, reject) => {
+    client.ex1({ msg: 'Hello from client!' }, (error: any, response: any) => {
+      error ? reject(error) : resolve(response);
+    });
+  });
+
+  console.log('Response:', response.msg);
+
+  // Stop server
+  await server.stop();
 }
 
-const example: Example = new Example();
-example.run();
+// Run example
+basicExample().catch(console.error);

--- a/example/multi-proto-example.ts
+++ b/example/multi-proto-example.ts
@@ -1,0 +1,95 @@
+import { GrpcMockServer } from '../src/GrpcMockServer';
+
+async function multiProtoExample() {
+  // Create mock server
+  const server = new GrpcMockServer();
+
+  // Define service implementation
+  const implementations = {
+    GetUser: (call: any, callback: any) => {
+      console.log('GetUser called with ID:', call.request.id);
+      
+      // Return user with address from different proto package
+      const user = {
+        name: 'John Doe',
+        address: {
+          postal_code: '12345',
+          city: 'San Francisco',
+          country: 'USA'
+        }
+      };
+      
+      callback(null, { user });
+    }
+  };
+
+  // Add service with multiple proto files
+  server.addService(
+    [
+      __dirname + '/user.proto',
+      __dirname + '/address.proto'
+    ],
+    'user',
+    'UserService',
+    implementations,
+    {
+      includeDirs: [__dirname],
+      keepCase: true,
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true
+    }
+  );
+
+  // Start server
+  await server.start();
+  console.log(`Multi-proto mock server listening at: ${server.serverAddress}`);
+
+  // Create client
+  const grpc = require('@grpc/grpc-js');
+  const proto_loader = require('@grpc/proto-loader');
+  const { ProtoUtils } = require('../src/utils/ProtoUtils');
+
+  const pkgDef = grpc.loadPackageDefinition(
+    proto_loader.loadSync([
+      __dirname + '/user.proto',
+      __dirname + '/address.proto'
+    ], {
+      includeDirs: [__dirname],
+      keepCase: true,
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true
+    })
+  );
+
+  const proto = ProtoUtils.getProtoFromPkgDefinition('user', pkgDef);
+  const client = new proto.UserService(
+    '127.0.0.1:50777',
+    grpc.credentials.createInsecure()
+  );
+
+  // Make request
+  const response = await new Promise<any>((resolve, reject) => {
+    client.GetUser({ id: '123' }, (error: any, response: any) => {
+      error ? reject(error) : resolve(response);
+    });
+  });
+
+  console.log('User response:', {
+    name: response.user.name,
+    address: {
+      postal_code: response.user.address.postal_code,
+      city: response.user.address.city,
+      country: response.user.address.country
+    }
+  });
+
+  // Stop server
+  await server.stop();
+}
+
+// Run example
+multiProtoExample().catch(console.error); 

--- a/example/user.proto
+++ b/example/user.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package user;
+
+import "address.proto";
+
+message User {
+  string name = 1;
+  common.Address address = 2;
+}
+
+service UserService {
+  rpc GetUser (UserRequest) returns (UserResponse);
+}
+
+message UserRequest {
+  string id = 1;
+}
+
+message UserResponse {
+  User user = 1;
+} 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build": "rm -rf ./dist && tsc --build tsconfig.json",
     "test": "jest",
     "lint": "eslint . --ext .ts --fix",
-    "prettier": "prettier --config .prettierrc 'src/**/*.ts' 'example/**/*.ts' 'tests/**/*.ts' --write"
+    "prettier": "prettier --config .prettierrc 'src/**/*.ts' 'example/**/*.ts' 'tests/**/*.ts' --write",
+    "example": "npm run build && npx ts-node ./example/example.ts",
+    "multi-proto-example": "npm run build && npx ts-node ./example/multi-proto-example.ts"
   },
   "repository": {
     "type": "git",

--- a/run-example.sh
+++ b/run-example.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
+echo "Running basic example..."
 npx ts-node ./example/example.ts

--- a/run-multi-proto-example.sh
+++ b/run-multi-proto-example.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+echo "Running multi-proto example..."
+npx ts-node ./example/multi-proto-example.ts 

--- a/tests/integration.test.ts
+++ b/tests/integration.test.ts
@@ -66,7 +66,14 @@ test('should support multi-proto modular import', async () => {
   const SERVICE_NAME = 'UserService';
 
   const pkgDef: grpc.GrpcObject = grpc.loadPackageDefinition(
-    proto_loader.loadSync(PROTO_PATHS, { includeDirs: [__dirname + '/resources'] })
+    proto_loader.loadSync(PROTO_PATHS, { 
+      includeDirs: [__dirname + '/resources'],
+      keepCase: true,
+      longs: String,
+      enums: String,
+      defaults: true,
+      oneofs: true
+    })
   );
   const proto: any = ProtoUtils.getProtoFromPkgDefinition(PKG_NAME, pkgDef);
 
@@ -77,7 +84,14 @@ test('should support multi-proto modular import', async () => {
       callback(null, response);
     }
   };
-  server.addService(PROTO_PATHS, PKG_NAME, SERVICE_NAME, implementations, { includeDirs: [__dirname + '/resources'] });
+  server.addService(PROTO_PATHS, PKG_NAME, SERVICE_NAME, implementations, { 
+    includeDirs: [__dirname + '/resources'],
+    keepCase: true,
+    longs: String,
+    enums: String,
+    defaults: true,
+    oneofs: true
+  });
 
   try {
     await server.start();


### PR DESCRIPTION
- Allow array of proto files in addService()
- Fix cross-package imports with proto-loader options
- Add examples for single and multi-proto usage

See: https://github.com/alenon/grpc-mock-server/issues/992