### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/alenon/grpc-mock-server/security/code-scanning/2](https://github.com/alenon/grpc-mock-server/security/code-scanning/2)

To fix this issue, you should add an explicit `permissions` block to the workflow, either at the root or in the relevant job (in this case, `build`). The permissions should reflect the minimum required for the job to function. Since the workflow updates `CHANGELOG.md` and likely pushes changes, it needs at least `contents: write`. If the action opens pull requests, add `pull-requests: write`. Place the permissions block either above `jobs:` (if it should apply to all jobs), or inside the specific `build:` job definition for just that job. No other functionality or steps need to change. No additional methods or imports beyond YAML keys are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
